### PR TITLE
Add `--save` option for `prediction create` subcommand

### DIFF
--- a/internal/cmd/prediction/create.go
+++ b/internal/cmd/prediction/create.go
@@ -172,7 +172,7 @@ func AddCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("no-wait", false, "Don't wait for prediction to complete")
 	cmd.Flags().BoolP("wait", "w", true, "Wait for prediction to complete")
 	cmd.Flags().Bool("web", false, "View on web")
-	cmd.Flags().StringP("separator", "s", "=", "Separator between input key and value")
+	cmd.Flags().String("separator", "=", "Separator between input key and value")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "web")
 	cmd.MarkFlagsMutuallyExclusive("wait", "no-wait")

--- a/internal/cmd/prediction/create.go
+++ b/internal/cmd/prediction/create.go
@@ -3,6 +3,7 @@ package prediction
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -144,6 +145,25 @@ var CreateCmd = &cobra.Command{
 						return fmt.Errorf("failed to marshal output: %w", err)
 					}
 					fmt.Println(string(bytes))
+
+					if cmd.Flags().Changed("save") {
+						var dirname string
+						if cmd.Flags().Changed("output-directory") {
+							dirname = cmd.Flag("output-directory").Value.String()
+						} else {
+							dirname = fmt.Sprintf("./%s", prediction.ID)
+						}
+
+						dir, err := filepath.Abs(dirname)
+						if err != nil {
+							return fmt.Errorf("failed to create output directory: %w", err)
+						}
+
+						err = util.DownloadPrediction(ctx, *prediction, dir)
+						if err != nil {
+							return fmt.Errorf("failed to save output: %w", err)
+						}
+					}
 				case replicate.Failed:
 					fmt.Println("❌ Failed")
 					fmt.Println(*prediction.Logs)
@@ -173,6 +193,8 @@ func AddCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("wait", "w", true, "Wait for prediction to complete")
 	cmd.Flags().Bool("web", false, "View on web")
 	cmd.Flags().String("separator", "=", "Separator between input key and value")
+	cmd.Flags().BoolP("save", "s", false, "Save prediction to file")
+	cmd.Flags().String("output-directory", "", "Output directory, defaults to ./{prediction-id}")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "web")
 	cmd.MarkFlagsMutuallyExclusive("wait", "no-wait")

--- a/internal/cmd/training/create.go
+++ b/internal/cmd/training/create.go
@@ -124,7 +124,7 @@ func AddCreateFlags(cmd *cobra.Command) {
 
 	cmd.Flags().Bool("json", false, "Emit JSON")
 	cmd.Flags().Bool("web", false, "View on web")
-	cmd.Flags().StringP("separator", "s", "=", "Separator between input key and value")
+	cmd.Flags().String("separator", "=", "Separator between input key and value")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "web")
 }

--- a/internal/util/download.go
+++ b/internal/util/download.go
@@ -1,0 +1,91 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/replicate/replicate-go"
+	"golang.org/x/sync/errgroup"
+)
+
+func DownloadPrediction(ctx context.Context, prediction replicate.Prediction, dir string) error {
+	if prediction.ID == "" {
+		return fmt.Errorf("prediction ID is empty")
+	}
+
+	if prediction.Status != replicate.Succeeded {
+		return fmt.Errorf("prediction is not finished")
+	}
+
+	if prediction.Output == nil {
+		return fmt.Errorf("prediction output is empty")
+	}
+
+	if dir == "" {
+		return fmt.Errorf("directory is empty")
+	}
+
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if reflect.TypeOf(prediction.Output).Kind() == reflect.Slice {
+		v := reflect.ValueOf(prediction.Output)
+		strings := make([]string, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			strings[i] = v.Index(i).Interface().(string)
+		}
+
+		g, _ := errgroup.WithContext(ctx)
+
+		for _, str := range strings {
+			u, err := url.ParseRequestURI(str)
+			if err != nil {
+				break
+			}
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+			if err != nil {
+				break
+			}
+
+			g.Go(func() error {
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					return fmt.Errorf("failed to download file %v: %w", u, err)
+				}
+				defer resp.Body.Close()
+
+				filename := filepath.Base(u.Path)
+				file, err := os.Create(filepath.Join(dir, filename))
+				if err != nil {
+					return fmt.Errorf("failed to create file %s: %w", filename, err)
+				}
+
+				_, err = io.Copy(file, resp.Body)
+				if err != nil {
+					return fmt.Errorf("failed to write file %s: %w", filename, err)
+				}
+
+				return nil
+			})
+		}
+
+		return g.Wait()
+	}
+
+	bytes, err := json.Marshal(prediction.Output)
+	if err != nil {
+		return fmt.Errorf("failed to marshal prediction output: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(dir, "output.json"), bytes, 0644)
+}


### PR DESCRIPTION
This PR adds `--save` and `--output-directory` options to the `prediction create` / `run` subcommands. If unspecified, `--output-directory` creates a new directory in the current directory named with the prediction ID.

```console
$ replicate run stability-ai/sdxl \
            prompt='a studio photo of a rainbow colored corgi' \
            width=512 height=512 seed=42069 num_outputs=4 \
            --save

Prediction created: https://replicate.com/p/6kpfwntbwkpojl75uhz6swtosu
processing 100% |████████████████████████████████████| (50/50, 4 it/s)         
✅ Succeeded                                                                   
[
  "https://replicate.delivery/pbxt/srkqTtLYv5b7H9s9YZYoecjRbkcHuMe8Rdkf7eKAyEVgQFpFB/out-0.png",
  "https://replicate.delivery/pbxt/Sq2HaK95m07gKZG3X1WkgNH4mv9A5n6ELnn9U3n4S1GCVkWE/out-1.png",
  "https://replicate.delivery/pbxt/Ni3Lqgf5211yOi0vcKIZou7HYQHeENddcQixbyaroKJIURaRA/out-2.png",
  "https://replicate.delivery/pbxt/naPAxJn4cFZVJtp6o3fDai7frWAvwvKk1blI71ukOPsJURaRA/out-3.png"
]
```

<img width="726" alt="6kpfwntbwkpoil75uhz6swtosu-output" src="https://github.com/replicate/cli/assets/7659/7e53bba7-93d1-47a8-9b86-19c02d25b468">

