### PR TITLE
add example usage for "replicate model create"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ $ replicate run stability-ai/sdxl \
 # opens prediction in browser (https://replicate.com/p/jpgp263bdekvxileu2ppsy46v4)
 ```
 
+### Create a model
+
+Create a new model on Replicate.
+
+```console
+$ replicate model create yourname/model --private --hardware gpu-a40-small
+```
+
+After creating your model, you can [fine-tune an existing model](https://replicate.com/docs/fine-tuning) or [build and push a custom model using Cog](https://replicate.com/docs/guides/push-a-model).
+
 ### Fine-tune a model
 
 Fine-tune [SDXL] with your own images:


### PR DESCRIPTION
This PR updates the README with an example of how to create a model and open it in the browser.

Pretty nice to end up here:

![Screenshot 2023-11-14 at 20 41 03](https://github.com/replicate/cli/assets/2289/59ebc948-de34-4029-8981-943410b92593)
