### PR TITLE
Set client `User-Agent` to `replicate-cli/{version}`

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -20,7 +20,7 @@ func NewClient(opts ...replicate.ClientOption) (*replicate.Client, error) {
 		return nil, fmt.Errorf("please authenticate with `replicate login`")
 	}
 
-	userAgent := fmt.Sprintf("replicate/%s", internal.Version())
+	userAgent := fmt.Sprintf("replicate-cli/%s", internal.Version())
 
 	opts = append([]replicate.ClientOption{
 		replicate.WithBaseURL(baseURL),


### PR DESCRIPTION
Currently, the CLI makes requests to Replicate's API with a `User-Agent` header set to `replicate/{version}`. This PR updates that to be `replicate-cli/{version}`, to avoid confusion with other clients.