### PR TITLE
Fix handling of empty tokens in `replicate auth login`

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,7 +17,7 @@ func NewClient(opts ...replicate.ClientOption) (*replicate.Client, error) {
 		return nil, fmt.Errorf("failed to get API token: %w", err)
 	}
 	if token == "" {
-		return nil, fmt.Errorf("please authenticate with `replicate login`")
+		return nil, fmt.Errorf("please authenticate with `replicate auth login`")
 	}
 
 	userAgent := fmt.Sprintf("replicate/%s", internal.Version())

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -38,6 +38,9 @@ You can find your Replicate API token at https://replicate.com/account`,
 			if err != nil {
 				return fmt.Errorf("failed to read token from stdin: %w", err)
 			}
+			if token == "" {
+				return fmt.Errorf("no token provided (empty string)")
+			}
 		} else {
 			return fmt.Errorf("token must be passed to stdin with --token-stdin flag")
 		}


### PR DESCRIPTION
Follow-up to #48 