### PR TITLE
Log config file location after successful authentication

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -49,8 +49,6 @@ github.com/replicate/replicate-go v0.8.1 h1:Mza5hWR/R1akZRKwXtA/CQJ2pY4/B9fSCYX+
 github.com/replicate/replicate-go v0.8.1/go.mod h1:k9C4+PaYa9+hMRjn4D7ZPHOCUFb8P4jhytsCqcGa2vU=
 github.com/replicate/replicate-go v0.13.0 h1:DWpSw8ck+dVK79jcVbg0iWJt4/ajcDaYX7FmiqSh2iI=
 github.com/replicate/replicate-go v0.13.0/go.mod h1:k9C4+PaYa9+hMRjn4D7ZPHOCUFb8P4jhytsCqcGa2vU=
-github.com/replicate/replicate-go v0.15.0 h1:irjAv6PI9H2o4H3sKkaHuQ35mKNC/0OQqNleYWNA4Sg=
-github.com/replicate/replicate-go v0.15.0/go.mod h1:otIrl1vDmyjNhTzmVmp/mQU3Wt1+3387gFNEsAZq0ig=
 github.com/sagikazarmark/crypt v0.6.0/go.mod h1:U8+INwJo3nBv1m6A/8OBXAq7Jnpspk5AxSgDyEQcea8=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/shirou/gopsutil/v3 v3.23.10/go.mod h1:JIE26kpucQi+innVlAUnIEOSBhBUkirr5b44yr55+WE=
@@ -68,5 +66,6 @@ go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 google.golang.org/api v0.81.0/go.mod h1:FA6Mb/bZxj706H2j+j2d6mHEEaHBmbbWnkfvmorOCko=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -58,7 +58,7 @@ You can find your Replicate API token at https://replicate.com/account`,
 			return fmt.Errorf("failed to set API token: %w", err)
 		}
 
-		fmt.Println("Login successful.")
+		fmt.Printf("Token saved to configuration file: %s\n", config.ConfigFilePath)
 
 		return nil
 	},

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -13,7 +13,7 @@ const (
 	DefaultBaseURL = "https://api.replicate.com/v1/"
 )
 
-var configFile string
+var ConfigFilePath string
 
 type config map[string]Host
 
@@ -24,11 +24,11 @@ type Host struct {
 func init() {
 	// Look for config in the XDG_CONFIG_HOME directory
 	if configDir, exists := os.LookupEnv("XDG_CONFIG_HOME"); exists {
-		configFile = filepath.Join(configDir, "replicate", "hosts")
+		ConfigFilePath = filepath.Join(configDir, "replicate", "hosts")
 	} else {
 		// Look for config in the default directory
 		if homeDir, err := os.UserHomeDir(); err == nil {
-			configFile = filepath.Join(homeDir, ".config", "replicate", "hosts")
+			ConfigFilePath = filepath.Join(homeDir, ".config", "replicate", "hosts")
 		}
 	}
 }
@@ -52,11 +52,11 @@ func GetAPITokenForHost(host string) (string, error) {
 		return "", fmt.Errorf("invalid host: %s", err)
 	}
 
-	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+	if _, err := os.Stat(ConfigFilePath); os.IsNotExist(err) {
 		return "", nil
 	}
 
-	data, err := os.ReadFile(configFile)
+	data, err := os.ReadFile(ConfigFilePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read config file: %w", err)
 	}
@@ -93,19 +93,19 @@ func SetAPITokenForHost(apiToken, host string) error {
 		return fmt.Errorf("invalid host: %s", err)
 	}
 
-	if _, err := os.Stat(configFile); os.IsNotExist(err) {
-		err = os.MkdirAll(filepath.Dir(configFile), 0o755)
+	if _, err := os.Stat(ConfigFilePath); os.IsNotExist(err) {
+		err = os.MkdirAll(filepath.Dir(ConfigFilePath), 0o755)
 		if err != nil {
 			return fmt.Errorf("failed to create config directory: %w", err)
 		}
 
-		_, err = os.Create(configFile)
+		_, err = os.Create(ConfigFilePath)
 		if err != nil {
 			return fmt.Errorf("failed to create config file: %w", err)
 		}
 	}
 
-	data, err := os.ReadFile(configFile)
+	data, err := os.ReadFile(ConfigFilePath)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func SetAPITokenForHost(apiToken, host string) error {
 		return fmt.Errorf("failed to marshal config file: %w", err)
 	}
 
-	err = os.WriteFile(configFile, data, 0o644)
+	err = os.WriteFile(ConfigFilePath, data, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}


### PR DESCRIPTION
`replicate auth login --token-stdin` saves the token passed to stdin to `$XDG_CONFIG_HOME/replicate/hosts` if defined, falling back to `~/.config/replicate/hosts`.

This PR updates the command to print exactly where the token was saved, which is helpful for debugging.

```console
$ echo $REPLICATE_API_TOKEN | replicate auth login --token-stdin
Token saved to configuration file: /Users/mattt/.config/replicate/hosts
```